### PR TITLE
Fixes for makeHttpCall .js HTTP request wrapper

### DIFF
--- a/makeHttpCall.js
+++ b/makeHttpCall.js
@@ -12,21 +12,19 @@ const axios = require('axios');
  * @throws {Error} If an error occurs during the request.
  */
 
-async function makeHttpCall(method, url, data = null, headers = {}) {
+async function makeHttpCall(method, url, data = undefined, headers = {}) {
   try {
-    const response = await axios({
-      method,
-      url,
-      data,
-      headers,
-    });
+    const options = {
+      url, method, headers, data
+    }
+
+    const response = await axios(options);
 
     return response;
   } catch (error) {
     throw error;
   }
 }
-
 
 module.exports = {
     makeHttpCall


### PR DESCRIPTION
When we make a GET call using this makeHttpCall Axios wrapper, it's throwing a 400 Bad Request error. I have observed this issue while dealing with conversation history and using the sdk.getMessages method of the Botkit SDK. This method internally resolves to a GET call to the conversation API of the Kore.ai platform.