### PR TITLE
SCA vulnerability addressed by removing the /gethistory endpoint

### DIFF
--- a/lib/app/routes.js
+++ b/lib/app/routes.js
@@ -20,7 +20,6 @@ function loadroutes(app) {
         serviceHandler(req, res, sdk.runComponentHandler(botId, 'default', eventName, reqBody));
     });
 
-    app.get( apiPrefix + '/gethistory', livechat.gethistory);
 }
 
 module.exports = {


### PR DESCRIPTION
Customers are responsible for implementing appropriate security controls for externally exposed endpoints. This route has been removed as part of SCA vulnerability.